### PR TITLE
ProductecaRequestError

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -3,6 +3,7 @@ Promise = require("bluebird")
 debug = require("debug")("producteca-sdk:client")
 debugResponse = require("debug")("producteca-sdk:client:response")
 debugResponseError = require("debug")("producteca-sdk:client:response:error")
+ProductecaRequestError = require('./exceptions/productecaRequestError')
 request = require("request-promise")
 
 module.exports =
@@ -43,6 +44,7 @@ class Client
     .tapCatch (err) ->
       __logWithLogtecaApiIfShould { requestOptions: options, fulfilled: false, err }
       debugResponseError(JSON.stringify(err.message or err.body or err.code or err.error or err))
+    .catch (({ statusCode, name }) -> _.startsWith(statusCode, "5") or name is "RequestError"), (err) -> throw new ProductecaRequestError(err)
 
   _makeUrl: (path) =>
     if path? then @url + path else @url

--- a/src/exceptions/productecaRequestError.coffee
+++ b/src/exceptions/productecaRequestError.coffee
@@ -3,7 +3,6 @@ _ = require "lodash"
 module.exports =
 class ProductecaRequestError extends Error
   constructor: (err) ->
-    # console.log err
     @name = "ProductecaRequestError"
     @statusCode = err?.statusCode or 502
     @body =

--- a/src/exceptions/productecaRequestError.coffee
+++ b/src/exceptions/productecaRequestError.coffee
@@ -8,6 +8,6 @@ class ProductecaRequestError extends Error
     @statusCode = err?.statusCode or 502
     @body =
       err: err
-      code: "external_request_error",
+      code: "producteca_request_error",
       message: _.get err, "message", "There was an error while making a request to an external server"
       payload: JSON.stringify _.omit err, ["response","options.headers","options.auth"]

--- a/src/exceptions/productecaRequestError.coffee
+++ b/src/exceptions/productecaRequestError.coffee
@@ -1,0 +1,13 @@
+_ = require "lodash"
+
+module.exports =
+class ProductecaRequestError extends Error
+  constructor: (err) ->
+    # console.log err
+    @name = "ProductecaRequestError"
+    @statusCode = err?.statusCode or 502
+    @body =
+      err: err
+      code: "external_request_error",
+      message: _.get err, "message", "There was an error while making a request to an external server"
+      payload: JSON.stringify _.omit err, ["response","options.headers","options.auth"]


### PR DESCRIPTION
ProductecaApi devuelve ProductecaRequestError cuando la request a una API de Producteca falla con statusCode 5xx o con un error de conexión

[Finishes #6679215003](https://producteca.monday.com/boards/427697446/views/13284263/pulses/6679215003)

- [ ] App levantada, probada y con los tests corridos! [👌](https://c.tenor.com/joILBoleQeoAAAAC/ricky-fort.gif)
